### PR TITLE
Address inline feedback for park data

### DIFF
--- a/app/parks/page.tsx
+++ b/app/parks/page.tsx
@@ -1,0 +1,26 @@
+import '@root/global.scss';
+
+import ParkCard from '@components/ParkCard';
+import Grid from '@components/Grid';
+import Row from '@components/Row';
+import DefaultLayout from '@components/page/DefaultLayout';
+import { PARKS } from '@data/parks';
+
+export const dynamic = 'force-static';
+
+export default function ParksPage() {
+  return (
+    <DefaultLayout previewPixelSRC="/template-app-icon.png">
+      <Grid>
+        <Row>
+          <h1>U.S. National Parks</h1>
+        </Row>
+      </Grid>
+      <Grid>
+        {PARKS.map((park) => (
+          <ParkCard key={park.id} park={park} />
+        ))}
+      </Grid>
+    </DefaultLayout>
+  );
+}

--- a/components/ParkCard.module.scss
+++ b/components/ParkCard.module.scss
@@ -1,0 +1,18 @@
+.image {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.memories {
+  padding-left: 16px;
+  margin: 0;
+}
+
+.memoryImage {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  margin-bottom: 4px;
+}

--- a/components/ParkCard.tsx
+++ b/components/ParkCard.tsx
@@ -1,0 +1,65 @@
+import styles from '@components/ParkCard.module.scss';
+import Card from '@components/Card';
+import Grid from '@components/Grid';
+import Row from '@components/Row';
+import Text from '@components/Text';
+import Badge from '@components/Badge';
+import * as React from 'react';
+import type { Park } from '@data/parks';
+
+interface ParkCardProps {
+  park: Park;
+}
+
+const ParkCard: React.FC<ParkCardProps> = ({ park }) => {
+  const heroImage = park.memories?.find((m) => m.image)?.image;
+
+  return (
+    <Card title={park.name} style={{ marginBottom: '1rem' }}>
+      <Grid>
+        {heroImage && (
+          <Row>
+            <img src={heroImage} alt={park.name} className={styles.image} />
+          </Row>
+        )}
+        <Row>
+          <Text>{park.description}</Text>
+        </Row>
+        <Row>
+          {park.states.map((state) => (
+            <Badge key={state}>{state}</Badge>
+          ))}
+        </Row>
+        {park.visits && park.visits.length > 0 && (
+          <Row>
+            {park.visits.map((visit, i) => (
+              <Badge key={i} style={{ marginLeft: i ? '0.5rem' : 0 }}>
+                {visit.start} - {visit.end}
+              </Badge>
+            ))}
+          </Row>
+        )}
+        {park.memories && park.memories.length > 0 && (
+          <Row>
+            <ul className={styles.memories}>
+              {park.memories.map((m, i) => (
+                <li key={i}>
+                  {m.image && (
+                    <img
+                      src={m.image}
+                      alt={m.text}
+                      className={styles.memoryImage}
+                    />
+                  )}
+                  {m.text}
+                </li>
+              ))}
+            </ul>
+          </Row>
+        )}
+      </Grid>
+    </Card>
+  );
+};
+
+export default ParkCard;

--- a/data/parks.ts
+++ b/data/parks.ts
@@ -1,0 +1,167 @@
+export interface Memory {
+  text: string;
+  image?: string;
+}
+
+export interface Visit {
+  start: string;
+  end: string;
+}
+
+export interface Park {
+  id: string;
+  name: string;
+  states: string[];
+  description: string;
+  visits?: Visit[];
+  memories?: Memory[];
+}
+
+export const PARKS: Park[] = [
+  {
+    id: 'acadia',
+    name: 'Acadia National Park',
+    states: ['Maine'],
+    description:
+      'Picturesque Atlantic coastline with granite peaks and rocky beaches.',
+  },
+  {
+    id: 'arches',
+    name: 'Arches National Park',
+    states: ['Utah'],
+    description: 'Home to over 2,000 natural sandstone arches.',
+  },
+  {
+    id: 'badlands',
+    name: 'Badlands National Park',
+    states: ['South Dakota'],
+    description: 'Fossil beds and striking layered rock formations.',
+  },
+  {
+    id: 'bryce-canyon',
+    name: 'Bryce Canyon National Park',
+    states: ['Utah'],
+    description: 'Known for crimson hoodoos and sweeping vistas.',
+    visits: [
+      { start: '2018-05-02', end: '2018-05-05' },
+    ],
+    memories: [
+      {
+        text: 'Sunrise at Bryce Point',
+        image: 'https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d?auto=format&fit=crop&w=800&q=60',
+      },
+    ],
+  },
+  {
+    id: 'denali',
+    name: 'Denali National Park',
+    states: ['Alaska'],
+    description: 'Six million acres of Alaskan wilderness centered on Denali peak.',
+  },
+  {
+    id: 'everglades',
+    name: 'Everglades National Park',
+    states: ['Florida'],
+    description: 'Vast wetlands preserve with mangroves and abundant wildlife.',
+  },
+  {
+    id: 'glacier',
+    name: 'Glacier National Park',
+    states: ['Montana'],
+    description: 'Rugged peaks, alpine meadows and many glaciers.',
+  },
+  {
+    id: 'grand-canyon',
+    name: 'Grand Canyon National Park',
+    states: ['Arizona'],
+    description: 'A natural wonder carving deep red rock for over 277 miles.',
+    visits: [
+      { start: '2019-07-10', end: '2019-07-12' },
+    ],
+    memories: [
+      {
+        text: 'Sunset at Hopi Point',
+        image: 'https://images.unsplash.com/photo-1508264165352-258859e62245?auto=format&fit=crop&w=800&q=60',
+      },
+    ],
+  },
+  {
+    id: 'grand-teton',
+    name: 'Grand Teton National Park',
+    states: ['Wyoming'],
+    description: 'Iconic jagged peaks rising above Jackson Hole valley.',
+  },
+  {
+    id: 'great-smoky-mountains',
+    name: 'Great Smoky Mountains National Park',
+    states: ['Tennessee', 'North Carolina'],
+    description: 'America\'s most visited park, famous for mist-covered mountains.',
+  },
+  {
+    id: 'joshua-tree',
+    name: 'Joshua Tree National Park',
+    states: ['California'],
+    description: 'Where the Mojave and Colorado deserts converge.',
+  },
+  {
+    id: 'olympic',
+    name: 'Olympic National Park',
+    states: ['Washington'],
+    description: 'Rainforests, alpine peaks and rugged Pacific coastline.',
+  },
+  {
+    id: 'redwood',
+    name: 'Redwood National Park',
+    states: ['California'],
+    description: 'Protects some of the tallest trees on Earth.',
+  },
+  {
+    id: 'rocky-mountain',
+    name: 'Rocky Mountain National Park',
+    states: ['Colorado'],
+    description: 'High peaks and alpine lakes in the Colorado Rockies.',
+    visits: [
+      { start: '2020-09-01', end: '2020-09-05' },
+    ],
+  },
+  {
+    id: 'sequoia',
+    name: 'Sequoia National Park',
+    states: ['California'],
+    description: 'Home to massive sequoia trees including General Sherman.',
+  },
+  {
+    id: 'shenandoah',
+    name: 'Shenandoah National Park',
+    states: ['Virginia'],
+    description: 'Skyline Drive runs the length of this scenic Appalachian park.',
+  },
+  {
+    id: 'yellowstone',
+    name: 'Yellowstone National Park',
+    states: ['Wyoming', 'Montana', 'Idaho'],
+    description: 'Home to geysers like Old Faithful and an array of wildlife.',
+  },
+  {
+    id: 'yosemite',
+    name: 'Yosemite National Park',
+    states: ['California'],
+    description: 'Famous for its towering granite cliffs and waterfalls.',
+    visits: [
+      { start: '2021-06-10', end: '2021-06-15' },
+    ],
+    memories: [
+      {
+        text: 'Hiked Half Dome',
+        image: 'https://images.unsplash.com/photo-1509112756314-34a0badb29d4?auto=format&fit=crop&w=800&q=60',
+      },
+      { text: 'Camped at Tuolumne Meadows' },
+    ],
+  },
+  {
+    id: 'zion',
+    name: 'Zion National Park',
+    states: ['Utah'],
+    description: 'Known for steep red cliffs and scenic canyon trails.',
+  },
+];


### PR DESCRIPTION
## Summary
- update `Park` interface to include multiple states, visits, and memory images
- expand dataset with more parks and date-based visit history
- display states, visits and memories in `ParkCard`
- adjust styles for memory images

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4967d0c0832ea7941bfc2b15242c