### PR TITLE
Add park encyclopedia landing and details

### DIFF
--- a/app/parks/[id]/page.tsx
+++ b/app/parks/[id]/page.tsx
@@ -1,0 +1,87 @@
+import '@root/global.scss';
+
+import DefaultLayout from '@components/page/DefaultLayout';
+import Grid from '@components/Grid';
+import Row from '@components/Row';
+import Text from '@components/Text';
+import Badge from '@components/Badge';
+import Card from '@components/Card';
+import Map from '@components/Map';
+import { PARKS } from '@data/parks';
+
+export const dynamic = 'force-static';
+
+export async function generateStaticParams() {
+  return PARKS.map((park) => ({ id: park.id }));
+}
+
+export default function ParkPage({ params }) {
+  const park = PARKS.find((p) => p.id === params.id);
+  if (!park) {
+    return (
+      <DefaultLayout previewPixelSRC="/template-app-icon.png">
+        <Grid>
+          <Row>Park not found.</Row>
+        </Grid>
+      </DefaultLayout>
+    );
+  }
+
+  const heroImage = park.memories?.find((m) => m.image)?.image;
+
+  return (
+    <DefaultLayout previewPixelSRC="/template-app-icon.png">
+      <Grid>
+        <Row>
+          <h1>{park.name}</h1>
+        </Row>
+        {heroImage && (
+          <Row>
+            <img src={heroImage} alt={park.name} style={{ width: '100%', borderRadius: '4px' }} />
+          </Row>
+        )}
+        <Row>
+          <Text>{park.description}</Text>
+        </Row>
+        <Row>
+          {park.states.map((state) => (
+            <Badge key={state}>{state}</Badge>
+          ))}
+        </Row>
+        {park.visits && park.visits.length > 0 && (
+          <Row>
+            <Card title="Past Visits">
+              <Grid>
+                {park.visits.map((visit, i) => (
+                  <Row key={i}>
+                    <Badge>{visit.start} - {visit.end}</Badge>
+                  </Row>
+                ))}
+              </Grid>
+            </Card>
+          </Row>
+        )}
+        <Row>
+          <Map query={park.name} />
+        </Row>
+        {park.memories && park.memories.length > 0 && (
+          <Row>
+            <Card title="Memories">
+              <ul className="memories">
+                {park.memories.map((m, i) => (
+                  <li key={i}>
+                    {m.image && (
+                      <img src={m.image} alt={m.text} style={{ width: '100%', borderRadius: '4px', marginBottom: '4px' }} />
+                    )}
+                    {m.text}
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </Row>
+        )}
+      </Grid>
+    </DefaultLayout>
+  );
+}
+

--- a/app/parks/page.tsx
+++ b/app/parks/page.tsx
@@ -18,7 +18,7 @@ export default function ParksPage() {
       </Grid>
       <Grid>
         {PARKS.map((park) => (
-          <ParkCard key={park.id} park={park} />
+          <ParkCard key={park.id} park={park} href={`/parks/${park.id}`} />
         ))}
       </Grid>
     </DefaultLayout>

--- a/components/Map.module.scss
+++ b/components/Map.module.scss
@@ -1,0 +1,5 @@
+.map {
+  width: 100%;
+  height: 450px;
+  border: 0;
+}

--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -1,0 +1,14 @@
+import styles from '@components/Map.module.scss';
+import * as React from 'react';
+
+interface MapProps {
+  query: string;
+}
+
+const Map: React.FC<MapProps> = ({ query }) => {
+  const src = `https://maps.google.com/maps?q=${encodeURIComponent(query)}&output=embed`;
+  return <iframe className={styles.map} src={src} loading="lazy" />;
+};
+
+export default Map;
+

--- a/components/ParkCard.module.scss
+++ b/components/ParkCard.module.scss
@@ -16,3 +16,4 @@
   border-radius: 4px;
   margin-bottom: 4px;
 }
+.link { text-decoration: none; color: inherit; }

--- a/components/ParkCard.tsx
+++ b/components/ParkCard.tsx
@@ -9,12 +9,13 @@ import type { Park } from '@data/parks';
 
 interface ParkCardProps {
   park: Park;
+  href?: string;
 }
 
-const ParkCard: React.FC<ParkCardProps> = ({ park }) => {
+const ParkCard: React.FC<ParkCardProps> = ({ park, href }) => {
   const heroImage = park.memories?.find((m) => m.image)?.image;
 
-  return (
+  const content = (
     <Card title={park.name} style={{ marginBottom: '1rem' }}>
       <Grid>
         {heroImage && (
@@ -60,6 +61,16 @@ const ParkCard: React.FC<ParkCardProps> = ({ park }) => {
       </Grid>
     </Card>
   );
+
+  if (href) {
+    return (
+      <a href={href} className={styles.link} role="link">
+        {content}
+      </a>
+    );
+  }
+
+  return content;
 };
 
 export default ParkCard;


### PR DESCRIPTION
## Summary
- make `ParkCard` optionally clickable
- list parks with links to individual pages
- create `Map` component for embedding maps
- show details for each park including memories and past visits

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6c6daaa8832e892b06a488a6f2ac