### PR TITLE
Update parks grid layout

### DIFF
--- a/app/parks/ParksPage.module.scss
+++ b/app/parks/ParksPage.module.scss
@@ -1,0 +1,9 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+}
+
+.title {
+  grid-column: 1 / -1;
+}

--- a/app/parks/page.tsx
+++ b/app/parks/page.tsx
@@ -5,6 +5,7 @@ import Grid from '@components/Grid';
 import DefaultLayout from '@components/page/DefaultLayout';
 import { PARKS } from '@data/parks';
 import DefaultActionBar from '@root/components/page/DefaultActionBar';
+import styles from './ParksPage.module.scss';
 
 export const dynamic = 'force-static';
 
@@ -12,9 +13,8 @@ export default function ParksPage() {
   return (
     <DefaultLayout>
       <DefaultActionBar />
-      <Grid>
-        <h1>U.S. National Parks</h1>
-
+      <Grid className={styles.grid}>
+        <h1 className={styles.title}>U.S. National Parks</h1>
         {PARKS.map((park) => (
           <ParkCard key={park.id} park={park} href={`/parks/${park.id}`} />
         ))}

--- a/components/ParkCard.module.scss
+++ b/components/ParkCard.module.scss
@@ -16,4 +16,16 @@
   border-radius: 4px;
   margin-bottom: 4px;
 }
-.link { text-decoration: none; color: inherit; }
+.link {
+  text-decoration: none;
+  color: var(--theme-text);
+  background: var(--theme-background);
+  display: block;
+  transition: background 200ms ease, color 200ms ease;
+
+  &:hover,
+  &:focus {
+    background: var(--theme-text);
+    color: var(--theme-background);
+  }
+}


### PR DESCRIPTION
## Summary
- add a page-specific stylesheet for the parks list
- display parks in a responsive grid
- invert ParkCard colors on hover to stand out

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc65102c832eaa95493144705f1a